### PR TITLE
Bugfix not set step props to previous step state, but to the baseConfig one

### DIFF
--- a/src/revelio/index.ts
+++ b/src/revelio/index.ts
@@ -307,86 +307,49 @@ export class Revelio {
 
   private setStepProps() {
     const stepOptions = this.journey[this.currentIndex]?.options;
-    this.placement =
-      stepOptions?.placement ?? this.baseConfig.placement ?? this.placement;
+    this.placement = stepOptions?.placement ?? this.baseConfig.placement;
     this.preventScrollIntoView =
       stepOptions?.preventScrollIntoView ??
-      this.baseConfig.preventScrollIntoView ??
-      this.preventScrollIntoView;
+      this.baseConfig.preventScrollIntoView;
     this.disableBlink =
-      stepOptions?.disableBlink ??
-      this.baseConfig.disableBlink ??
-      this.disableBlink;
+      stepOptions?.disableBlink ?? this.baseConfig.disableBlink;
     this.persistBlink =
-      stepOptions?.persistBlink ??
-      this.baseConfig.persistBlink ??
-      this.persistBlink;
+      stepOptions?.persistBlink ?? this.baseConfig.persistBlink;
     this.disableClick =
-      stepOptions?.disableClick ??
-      this.baseConfig.disableClick ??
-      this.disableClick;
-    this.nextOnClick =
-      stepOptions?.nextOnClick ??
-      this.baseConfig.nextOnClick ??
-      this.nextOnClick;
+      stepOptions?.disableClick ?? this.baseConfig.disableClick;
+    this.nextOnClick = stepOptions?.nextOnClick ?? this.baseConfig.nextOnClick;
     this.showStepsInfo =
-      stepOptions?.showStepsInfo ??
-      this.baseConfig.showStepsInfo ??
-      this.showStepsInfo;
-    this.dialogClass =
-      stepOptions?.dialogClass ??
-      this.baseConfig.dialogClass ??
-      this.dialogClass;
-    this.titleClass =
-      stepOptions?.titleClass ?? this.baseConfig.titleClass ?? this.titleClass;
+      stepOptions?.showStepsInfo ?? this.baseConfig.showStepsInfo;
+    this.dialogClass = stepOptions?.dialogClass ?? this.baseConfig.dialogClass;
+    this.titleClass = stepOptions?.titleClass ?? this.baseConfig.titleClass;
     this.contentClass =
-      stepOptions?.contentClass ??
-      this.baseConfig.contentClass ??
-      this.contentClass;
+      stepOptions?.contentClass ?? this.baseConfig.contentClass;
     this.stepsInfoClass =
-      stepOptions?.stepsInfoClass ??
-      this.baseConfig.stepsInfoClass ??
-      this.stepsInfoClass;
-    this.btnClass =
-      stepOptions?.btnClass ?? this.baseConfig.btnClass ?? this.btnClass;
+      stepOptions?.stepsInfoClass ?? this.baseConfig.stepsInfoClass;
+    this.btnClass = stepOptions?.btnClass ?? this.baseConfig.btnClass;
     this.preventDefaultStyles =
-      stepOptions?.preventDefaultStyles ??
-      this.baseConfig.preventDefaultStyles ??
-      this.preventDefaultStyles;
-    this.prevBtnText =
-      stepOptions?.prevBtnText ??
-      this.baseConfig.prevBtnText ??
-      this.prevBtnText;
-    this.nextBtnText =
-      stepOptions?.nextBtnText ??
-      this.baseConfig.nextBtnText ??
-      this.nextBtnText;
-    this.skipBtnText =
-      stepOptions?.skipBtnText ??
-      this.baseConfig.skipBtnText ??
-      this.skipBtnText;
-    this.doneBtnText =
-      stepOptions?.doneBtnText ??
-      this.baseConfig.doneBtnText ??
-      this.doneBtnText;
+      stepOptions?.preventDefaultStyles ?? this.baseConfig.preventDefaultStyles;
+    this.prevBtnText = stepOptions?.prevBtnText ?? this.baseConfig.prevBtnText;
+    this.nextBtnText = stepOptions?.nextBtnText ?? this.baseConfig.nextBtnText;
+    this.skipBtnText = stepOptions?.skipBtnText ?? this.baseConfig.skipBtnText;
+    this.doneBtnText = stepOptions?.doneBtnText ?? this.baseConfig.doneBtnText;
     this.showPrevBtn = stepOptions?.showPrevBtn ?? this.currentIndex > 0;
     this.showNextBtn =
       stepOptions?.showNextBtn ?? this.currentIndex < this.journey.length - 1;
     this.showSkipBtn =
       stepOptions?.showSkipBtn ??
       (this.currentIndex < this.journey.length - 1 &&
-        (this.baseConfig.showSkipBtn ?? this.showSkipBtn));
+        this.baseConfig.showSkipBtn);
     this.showDoneBtn =
       stepOptions?.showDoneBtn ??
       (this.currentIndex === this.journey.length - 1 &&
-        (this.baseConfig.showDoneBtn ?? this.showDoneBtn));
-    this.onStart =
-      stepOptions?.onStart ?? this.baseConfig.onStart ?? this.onStart;
-    this.onEnd = stepOptions?.onEnd ?? this.baseConfig.onEnd ?? this.onEnd;
-    this.onNext = stepOptions?.onNext ?? this.baseConfig.onNext ?? this.onNext;
-    this.onPrev = stepOptions?.onPrev ?? this.baseConfig.onPrev ?? this.onPrev;
-    this.onSkip = stepOptions?.onSkip ?? this.baseConfig.onSkip ?? this.onSkip;
-    this.onDone = stepOptions?.onDone ?? this.baseConfig.onDone ?? this.onDone;
+        this.baseConfig.showDoneBtn);
+    this.onStart = stepOptions?.onStart ?? this.baseConfig.onStart;
+    this.onEnd = stepOptions?.onEnd ?? this.baseConfig.onEnd;
+    this.onNext = stepOptions?.onNext ?? this.baseConfig.onNext;
+    this.onPrev = stepOptions?.onPrev ?? this.baseConfig.onPrev;
+    this.onSkip = stepOptions?.onSkip ?? this.baseConfig.onSkip;
+    this.onDone = stepOptions?.onDone ?? this.baseConfig.onDone;
   }
 
   /**

--- a/src/revelio/index.ts
+++ b/src/revelio/index.ts
@@ -825,6 +825,8 @@ export class Revelio {
     this.renderOverlay();
 
     await this.mountStep();
+    
+    this.onStart?.();
   }
 
   public async end() {


### PR DESCRIPTION
---
name: Bugfix not set step props to previous step state, but to the baseConfig one
about: Bugfix not set step props to previous step state, but to the baseConfig one
title: 'Fix: '
labels: 'fix'
---

**Related Issue(s)**
none

**Include Tests for the New/Fixed Functionality**
TODO

**Describe the Changes**
Fixes a bug in which the instance was setting the prop that was used in the previous step when there wasn't a prop explicitely defined in the new step or in the baseConfig of the instance. Now it defaults to the baseConfig even if it is undefined as it doesn't have nothing undefined that is not supported to be undefined.

**Checklist**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.