### PR TITLE
Remove custom rootElement argument on constructor

### DIFF
--- a/src/revelio/index.ts
+++ b/src/revelio/index.ts
@@ -293,17 +293,12 @@ export class Revelio {
 
   constructor({
     journey,
-    rootElement,
     options,
   }: {
     /**
      * The feature journey steps for the Revelio instance
      */
     journey: JourneyStep[];
-    /**
-     * The root element for the Revelio instance
-     */
-    rootElement?: HTMLElement | string;
     /**
      * The global options for the Revelio instance. Will be applied to all steps unless overridden by the step's options.
      */
@@ -319,17 +314,7 @@ export class Revelio {
     this.currentIndex = 0;
     this.setStepProps();
 
-    // validate root element or default to document.body
-    const element =
-      typeof rootElement === 'string'
-        ? document.querySelector(rootElement)
-        : rootElement;
-    if (rootElement && !element)
-      throw new Error(`Element ${element} not found`);
-    if (element && !(element instanceof HTMLElement))
-      throw new Error(`Element ${element} is not an HTMLElement`);
-
-    this.rootElement = element ?? document.body;
+    this.rootElement = document.body;
   }
 
   get journey() {


### PR DESCRIPTION
---
name: Remove custom rootElement argument on constructor
about: Removes the possibility of usisng a custom rootElement, it will be document.body by default without any other option until is really needed for some use case
title: 'Change: Remove custom rootElement argument on constructor'
labels: 'change'
---

**Related Issue(s)**
none

**Include Tests for the New/Fixed Functionality**
no

**Describe the Changes**
Removes the possibility of usisng a custom rootElement, it will be document.body by default without any other option until is really needed for some use case

**Checklist**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.