### PR TITLE
Add opacity or overlay to ancestor stacking contexts elements

### DIFF
--- a/_implementations/vanilla/index.html
+++ b/_implementations/vanilla/index.html
@@ -191,6 +191,7 @@
               >
                 Click me
               </button>
+              <p class="text-purple-300">some more text here</p>
             </div>
           </section>
         </main>

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,3 +1,4 @@
 declare function arrayFromString(classString: string): string[];
 declare function getNumberFromString(string: string): number;
-export { arrayFromString, getNumberFromString };
+declare function getBgAlphaFromElement(element: Element): number | undefined;
+export { arrayFromString, getNumberFromString, getBgAlphaFromElement };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,4 +6,18 @@ function getNumberFromString(string: string) {
   return Number(string.replace(/[^0-9]/g, ''));
 }
 
-export { arrayFromString, getNumberFromString };
+function getBgAlphaFromElement(element: Element) {
+  const backgroundColor = window.getComputedStyle(element).backgroundColor;
+  if (backgroundColor.startsWith('rgba')) {
+    return parseFloat(
+      backgroundColor.slice(backgroundColor.lastIndexOf(',') + 1, -1),
+    );
+  } else if (backgroundColor.startsWith('rgb')) {
+    return 1;
+  } else {
+    console.warn('Unsupported color format:', backgroundColor);
+    return undefined;
+  }
+}
+
+export { arrayFromString, getNumberFromString, getBgAlphaFromElement };


### PR DESCRIPTION
---
name: Add opacity or overlay to ancestor stacking contexts elements
about: Add opacity or overlay to ancestor stacking contexts elements based on its background color. This is done to make less visible the elements (by adding opacity) that are not the highlighted element in the cases where a semi-transparent overlay, what is used regularly, is not possible to add because the stacking contexts background overlaps with the global overlay, causing a darker zone where they overlap. The opacity trick is only applied when the background is transparent, when it is solid, having the stacking context overlay with the same color than the global overlay works well.
title: 'Feature: Add opacity or overlay to ancestor stacking contexts elements'
labels: 'feature'
---

**Related Issue(s)**
none

**Include Tests for the New/Fixed Functionality**
TODO

**Describe the Changes**
Add opacity or overlay to ancestor stacking contexts elements based on its background color. This is done to make less visible the elements (by adding opacity) that are not the highlighted element in the cases where a semi-transparent overlay, what is used regularly, is not possible to add because the stacking contexts background overlaps with the global overlay, causing a darker zone where they overlap. The opacity trick is only applied when the background is transparent, when it is solid, having the stacking context overlay with the same color than the global overlay works well.

**Checklist**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.